### PR TITLE
Remove Xcode Beta dependency

### DIFF
--- a/StarWarsDemo.xcodeproj/project.pbxproj
+++ b/StarWarsDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXContainerItemProxy section */
@@ -22,16 +22,8 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		4BE0C1C12C87839000AFC3B1 /* StarWarsDemo */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = StarWarsDemo;
-			sourceTree = "<group>";
-		};
-		4BE0C1E42C879FBF00AFC3B1 /* StarWarsDemoTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = StarWarsDemoTests;
-			sourceTree = "<group>";
-		};
+		4BE0C1C12C87839000AFC3B1 /* StarWarsDemo */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = StarWarsDemo; sourceTree = "<group>"; };
+		4BE0C1E42C879FBF00AFC3B1 /* StarWarsDemoTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = StarWarsDemoTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +130,7 @@
 				};
 			};
 			buildConfigurationList = 4BE0C1BA2C87839000AFC3B1 /* Build configuration list for PBXProject "StarWarsDemo" */;
+			compatibilityVersion = "Xcode 15.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -146,7 +139,6 @@
 			);
 			mainGroup = 4BE0C1B62C87839000AFC3B1;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
 			productRefGroup = 4BE0C1C02C87839000AFC3B1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/StarWarsDemo.xcodeproj/project.pbxproj
+++ b/StarWarsDemo.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -301,7 +301,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -319,7 +319,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"StarWarsDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = ZS8A7XMWJ4;
+				DEVELOPMENT_TEAM = 9TAXVQDQJU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -327,6 +327,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -348,7 +349,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"StarWarsDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = ZS8A7XMWJ4;
+				DEVELOPMENT_TEAM = 9TAXVQDQJU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -356,6 +357,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/StarWarsDemo.xcodeproj/project.pbxproj
+++ b/StarWarsDemo.xcodeproj/project.pbxproj
@@ -3,8 +3,22 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 63;
 	objects = {
+
+/* Begin PBXBuildFile section */
+		27CE81F92C8B9BC900A914E9 /* StarWarsDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE81F72C8B9BC900A914E9 /* StarWarsDemoTests.swift */; };
+		27CE82062C8B9BE100A914E9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE81FE2C8B9BE100A914E9 /* ContentView.swift */; };
+		27CE82072C8B9BE100A914E9 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE81FF2C8B9BE100A914E9 /* Model.swift */; };
+		27CE82082C8B9BE100A914E9 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE82002C8B9BE100A914E9 /* Repository.swift */; };
+		27CE82092C8B9BE100A914E9 /* StarCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE82012C8B9BE100A914E9 /* StarCardView.swift */; };
+		27CE820A2C8B9BE100A914E9 /* StarCardVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE82022C8B9BE100A914E9 /* StarCardVM.swift */; };
+		27CE820B2C8B9BE100A914E9 /* StarWarsDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CE82042C8B9BE100A914E9 /* StarWarsDemoApp.swift */; };
+		27CE820C2C8B9BE100A914E9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27CE81FA2C8B9BE100A914E9 /* Preview Assets.xcassets */; };
+		27CE820D2C8B9BE100A914E9 /* StarWars Test.json in Resources */ = {isa = PBXBuildFile; fileRef = 27CE81FB2C8B9BE100A914E9 /* StarWars Test.json */; };
+		27CE820E2C8B9BE100A914E9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27CE81FD2C8B9BE100A914E9 /* Assets.xcassets */; };
+		27CE820F2C8B9BE100A914E9 /* StarWars.json in Resources */ = {isa = PBXBuildFile; fileRef = 27CE82032C8B9BE100A914E9 /* StarWars.json */; };
+/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		4BE0C1E72C879FBF00AFC3B1 /* PBXContainerItemProxy */ = {
@@ -17,14 +31,20 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		27CE81F72C8B9BC900A914E9 /* StarWarsDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarWarsDemoTests.swift; sourceTree = "<group>"; };
+		27CE81FA2C8B9BE100A914E9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		27CE81FB2C8B9BE100A914E9 /* StarWars Test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "StarWars Test.json"; sourceTree = "<group>"; };
+		27CE81FD2C8B9BE100A914E9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		27CE81FE2C8B9BE100A914E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		27CE81FF2C8B9BE100A914E9 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		27CE82002C8B9BE100A914E9 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
+		27CE82012C8B9BE100A914E9 /* StarCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarCardView.swift; sourceTree = "<group>"; };
+		27CE82022C8B9BE100A914E9 /* StarCardVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarCardVM.swift; sourceTree = "<group>"; };
+		27CE82032C8B9BE100A914E9 /* StarWars.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = StarWars.json; sourceTree = "<group>"; };
+		27CE82042C8B9BE100A914E9 /* StarWarsDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarWarsDemoApp.swift; sourceTree = "<group>"; };
 		4BE0C1BF2C87839000AFC3B1 /* StarWarsDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StarWarsDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BE0C1E32C879FBF00AFC3B1 /* StarWarsDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StarWarsDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		4BE0C1C12C87839000AFC3B1 /* StarWarsDemo */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = StarWarsDemo; sourceTree = "<group>"; };
-		4BE0C1E42C879FBF00AFC3B1 /* StarWarsDemoTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = StarWarsDemoTests; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		4BE0C1BC2C87839000AFC3B1 /* Frameworks */ = {
@@ -44,11 +64,44 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		27CE81F82C8B9BC900A914E9 /* StarWarsDemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				27CE81F72C8B9BC900A914E9 /* StarWarsDemoTests.swift */,
+			);
+			path = StarWarsDemoTests;
+			sourceTree = "<group>";
+		};
+		27CE81FC2C8B9BE100A914E9 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				27CE81FA2C8B9BE100A914E9 /* Preview Assets.xcassets */,
+				27CE81FB2C8B9BE100A914E9 /* StarWars Test.json */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		27CE82052C8B9BE100A914E9 /* StarWarsDemo */ = {
+			isa = PBXGroup;
+			children = (
+				27CE81FC2C8B9BE100A914E9 /* Preview Content */,
+				27CE81FD2C8B9BE100A914E9 /* Assets.xcassets */,
+				27CE81FE2C8B9BE100A914E9 /* ContentView.swift */,
+				27CE81FF2C8B9BE100A914E9 /* Model.swift */,
+				27CE82002C8B9BE100A914E9 /* Repository.swift */,
+				27CE82012C8B9BE100A914E9 /* StarCardView.swift */,
+				27CE82022C8B9BE100A914E9 /* StarCardVM.swift */,
+				27CE82032C8B9BE100A914E9 /* StarWars.json */,
+				27CE82042C8B9BE100A914E9 /* StarWarsDemoApp.swift */,
+			);
+			path = StarWarsDemo;
+			sourceTree = "<group>";
+		};
 		4BE0C1B62C87839000AFC3B1 = {
 			isa = PBXGroup;
 			children = (
-				4BE0C1C12C87839000AFC3B1 /* StarWarsDemo */,
-				4BE0C1E42C879FBF00AFC3B1 /* StarWarsDemoTests */,
+				27CE82052C8B9BE100A914E9 /* StarWarsDemo */,
+				27CE81F82C8B9BC900A914E9 /* StarWarsDemoTests */,
 				4BE0C1C02C87839000AFC3B1 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -77,9 +130,6 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				4BE0C1C12C87839000AFC3B1 /* StarWarsDemo */,
-			);
 			name = StarWarsDemo;
 			packageProductDependencies = (
 			);
@@ -99,9 +149,6 @@
 			);
 			dependencies = (
 				4BE0C1E82C879FBF00AFC3B1 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				4BE0C1E42C879FBF00AFC3B1 /* StarWarsDemoTests */,
 			);
 			name = StarWarsDemoTests;
 			packageProductDependencies = (
@@ -154,6 +201,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27CE820C2C8B9BE100A914E9 /* Preview Assets.xcassets in Resources */,
+				27CE820D2C8B9BE100A914E9 /* StarWars Test.json in Resources */,
+				27CE820E2C8B9BE100A914E9 /* Assets.xcassets in Resources */,
+				27CE820F2C8B9BE100A914E9 /* StarWars.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,6 +222,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27CE82062C8B9BE100A914E9 /* ContentView.swift in Sources */,
+				27CE82072C8B9BE100A914E9 /* Model.swift in Sources */,
+				27CE82082C8B9BE100A914E9 /* Repository.swift in Sources */,
+				27CE82092C8B9BE100A914E9 /* StarCardView.swift in Sources */,
+				27CE820A2C8B9BE100A914E9 /* StarCardVM.swift in Sources */,
+				27CE820B2C8B9BE100A914E9 /* StarWarsDemoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,6 +235,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27CE81F92C8B9BC900A914E9 /* StarWarsDemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StarWarsDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/StarWarsDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Descripción general
Este PR elimina la dependencia de utilizar Xcode Beta para abrir y trabajar con el proyecto. Ahora, el proyecto es totalmente compatible con la versión de Xcode 15.3 y con iOS 17, evitando así la dependencia de las versiones beta de iOS (anteriormente iOS 18 y Xcode 16).

## Motivo de la solicitud
Se busca mejorar la accesibilidad del proyecto al permitir que más desarrolladores puedan contribuir sin la necesidad de usar versiones beta de Xcode y iOS, facilitando el desarrollo en un entorno más estable y reduciendo problemas de compatibilidad.

## Cambios técnicos
El cambio consiste en actualizar las configuraciones de proyecto y ajustes específicos que requerían Xcode Beta. Esto incluye la modificación de configuraciones de build settings y la revisión de cualquier dependencia o configuración que utilizara características exclusivas de la versión beta. Ahora el proyecto puede abrirse y compilarse sin problemas en la versión estable de Xcode 15.3, y la aplicación es compatible con dispositivos que ejecutan iOS 17.

## Comprobaciones realizadas
Antes de subir el cambio, realicé los siguientes checks:
- Abrí el proyecto con la versión estable más reciente de Xcode 15.4.
- Verifiqué que todas las dependencias y configuraciones de compilación funcionen correctamente.
- Ejecuté el proyecto y confirmé que las pruebas unitarias pasen sin errores.
- Probé la aplicación en un iPhone con iOS 17.4.1 para confirmar su compatibilidad y funcionamiento correcto.

## Capturas de pantalla
![Screenshot at Sep 06 14-26-17](https://github.com/user-attachments/assets/8d236141-e34e-4e00-8c3f-0a30ddfd88bf)

